### PR TITLE
Add Spring Cloud Gateway discovery locator settings

### DIFF
--- a/gatewayserver.yml
+++ b/gatewayserver.yml
@@ -1,6 +1,13 @@
 server:
   port: 8072
 
+spring:
+  cloud:
+    gateway:
+      discovery:
+        locator:
+          enabled: true
+
 eureka:
   instance:
     preferIpAddress: true


### PR DESCRIPTION
Enable Spring Cloud Gateway discovery locator in configuration.